### PR TITLE
Add Nextflow 26.04 webinar talk entry

### DIFF
--- a/src/content/talks/2026/06/17/whats_new_nextflow_26-04.md
+++ b/src/content/talks/2026/06/17/whats_new_nextflow_26-04.md
@@ -1,0 +1,22 @@
+---
+title: "Webinar: What's new in Nextflow 26.04"
+description: Seqera Webinar with Ben Sherman about strict syntax, records, static typing and the new Module Registry
+online: true
+type: Webinar
+logoImage: /images/work/seqera_logo.svg
+logoImageDark: /images/work/seqera_logo_dark.svg
+eventURLs:
+  - https://seqera.io/events/what-s-new-in-nextflow-26-04-strict-syntax-records-static-typing-and-the-module-registry/
+pdfURLs: []
+youtubeIDs:
+  - s_DXaQyw9xs
+date: 2026-06-17
+---
+
+A Seqera Webinar walking through everything that's new in the Nextflow 26.04
+release: strict syntax, records, static typing and the new Module Registry.
+
+Ben and I gave an overview of the key updates followed by plenty of live demo,
+showing off the new language features and how the Module Registry lets you
+search, install and run modules (including all nf-core modules) directly from
+the command line.


### PR DESCRIPTION
## Summary
Adds a new talk entry for the Seqera webinar "What's new in Nextflow 26.04" featuring Ben Sherman discussing strict syntax, records, static typing, and the Module Registry.

## Changes
- Created new talk markdown file at `src/content/talks/2026/06/17/whats_new_nextflow_26-04.md`
- Includes webinar metadata with Seqera branding (logo images for light and dark modes)
- Links to the official event page and YouTube recording (ID: `s_DXaQyw9xs`)
- Follows the established talk content schema with proper frontmatter fields

## Details
The entry documents a Seqera webinar with comprehensive coverage of Nextflow 26.04 features, including live demonstrations of new language features and the Module Registry functionality for searching and installing modules directly from the command line.

https://claude.ai/code/session_01V5oGPyK9BiKQmdjC88tukD